### PR TITLE
Use double quotes in SSH command.

### DIFF
--- a/src/services/Ssh.php
+++ b/src/services/Ssh.php
@@ -76,7 +76,7 @@ class Ssh extends Component
      */
     public function upload($src, $target)
     {
-        $cmd = "cat {$src} | gzip | ssh {$this->remote} 'zcat > {$target}'";
+        $cmd = "cat {$src} | gzip | ssh {$this->remote} \"zcat > {$target}\"";
         $process = new Process($cmd);
         $process->run();
 
@@ -99,7 +99,7 @@ class Ssh extends Component
      */
     public function download($src, $target)
     {
-        $cmd = "ssh {$this->remote} 'cat {$src} | gzip' | zcat > {$target}";
+        $cmd = "ssh {$this->remote} \"cat {$src} | gzip | zcat > {$target}\"";
         $process = new Process($cmd);
         $process->run();
 


### PR DESCRIPTION
This works on Windows too.

@ostark: I tested only on Windows, so please confirm before merging.


```shell
xmr@xmr-PC MSYS /c/Users/xmr/Desktop/foo
$ ./craft copy/db/down

Export DB remote - import locally: foostaging
---------------------------------------------------

 Are you sure? (yes/no) [yes]:
 >

Dump imported
====================================================================== 100 %
time:  11 secs/11 secs

Performed steps:
----------------

 * Creating dump on remote (./storage/craft-copy-transfer.sql)
 * Downloading dump from remote ./storage/craft-copy-transfer.sql
 * Creating backup of local DB (./storage/craft-copy-recent.sql)
 * Importing dump

Rollback?
---------

php craft copy/db/from-file ./storage/craft-copy-recent.sql

```

Refs #4 