### PR TITLE
Remove the unused `DASHBOARD_URL`

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,10 +52,8 @@ class Plugin extends BasePlugin
         'eu2' => 'EU (AWS EU-WEST-1 / Ireland)'
     ];
 
-    const DASHBOARD_URL = "https://dashboard.fortrabbit.com";
-
     /**
-     * Initialize Plugins
+     * Initialize Plugin
      */
     public function init()
     {


### PR DESCRIPTION
@ostark: This is untested, but I couldn't find any other instances of `DASHBOARD_URL`.
