### PR TITLE
Better error messages for SSH keys and mysqldump missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Make sure that your local development enviornment stays the master for structura
 
 ### Automatic migrations
 
-Craft Copy incorporates another plugin called [Craft auto migrate](https://github.com/fortrabbit/craft-auto-migrate). It makes sure that database migrations will always run when deploying. That means that every time you'll push code via Git a database migration will be triggered, so that changes from `project.yml` will always be applied right away, without the need to trigger them manually by clicking the apply changes button with the Control Panel.
+Craft Copy incorporates another package called [Craft auto migrate](https://github.com/fortrabbit/craft-auto-migrate). It makes sure that database migrations will always run when deploying. That means that every time you'll push code via Git, a database migration will be triggered and changes from `project.yml` will be applied right away, without the need to click the apply changes button with the Control Panel.
 
 
 ### Multi staging

--- a/src/Actions/SetupAction.php
+++ b/src/Actions/SetupAction.php
@@ -22,7 +22,7 @@ class SetupAction extends Action
     use ConsoleOutputHelper;
     use PathHelper;
 
-    public const TROUBLE_SHOOTING_MYSQLDUMP_URL = "https://github.com/fortrabbit/craft-copy#trouble-shooting";
+    public const TROUBLE_SHOOTING_MYSQLDUMP_URL = "https://github.com/fortrabbit/craft-copy#the-mysqldump-command-does-not-exist";
     public const TROUBLE_SHOOTING_SSH_URL = "https://help.fortrabbit.com/ssh-keys";
 
 
@@ -76,12 +76,12 @@ class SetupAction extends Action
 
 
         if (!$mysql) {
-            $this->errorBlock('Mysqldump is required.');
+            $this->errorBlock('Mysqldump is required. Please install it with your local development environment.');
             $this->line("Get Help: " . self::TROUBLE_SHOOTING_MYSQLDUMP_URL);
         }
 
         if (!$ssh) {
-            $this->errorBlock('SSH key authentication is required here. Please add your SSH key to your fortrabbit Account first.');
+            $this->errorBlock('SSH key authentication is required. Please add your SSH key to your fortrabbit Account first.');
             $this->line("Get Help: " . self::TROUBLE_SHOOTING_SSH_URL);
         }
 

--- a/src/Actions/SetupAction.php
+++ b/src/Actions/SetupAction.php
@@ -81,7 +81,7 @@ class SetupAction extends Action
         }
 
         if (!$ssh) {
-            $this->errorBlock('SSH is required.');
+            $this->errorBlock('SSH key authentication is required here. Please add your SSH key to your fortrabbit Account first.');
             $this->line("Get Help: " . self::TROUBLE_SHOOTING_SSH_URL);
         }
 


### PR DESCRIPTION
For the issue: https://github.com/fortrabbit/craft-copy/issues/49, also:

* corrected the link to the mysqldump help
* improved a bit on mysqldump