### PR TITLE
Change timeout for  before/after commands to 300s, allow override via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can run any script before or after you run common up/down commands with Craf
 
 * Place the before/after scripts in your [Craft Copy config file](#config-file). 
 * The before/after commands will run on your local machine, not on the fortrabbit App. To run scripts while deploying, consider the Composer `post-install-cmd`.
-
+* The default timeout for before/after scripts is 300 seconds, which should be long enough for most use cases. If you need to allow a script to run for longer you can set a `CRAFT_COPY_SCRIPT_TIMEOUT` environment variable to an integer number of time in seconds to increase it.
 
 #### Supported commands
 

--- a/src/Helpers/DeployHooksHelper.php
+++ b/src/Helpers/DeployHooksHelper.php
@@ -6,6 +6,8 @@ namespace fortrabbit\Copy\Helpers;
 
 use Symfony\Component\Process\Process;
 
+use craft\helpers\App;
+
 trait DeployHooksHelper
 {
     use ConsoleOutputHelper;
@@ -42,9 +44,12 @@ trait DeployHooksHelper
 
         $this->head("Run $when scripts", null, false);
 
+        $timeout = App::env('CRAFT_COPY_SCRIPT_TIMEOUT') ?: 300;
+
         foreach ($scripts as $script) {
             $this->cmdBlock($script);
             $process = Process::fromShellCommandline($script);
+            $process-setTimeout($timeout);
             $process->run();
             if (! $process->isSuccessful()) {
                 $this->errorBlock($process->getErrorOutput());

--- a/src/Helpers/DeployHooksHelper.php
+++ b/src/Helpers/DeployHooksHelper.php
@@ -49,7 +49,7 @@ trait DeployHooksHelper
         foreach ($scripts as $script) {
             $this->cmdBlock($script);
             $process = Process::fromShellCommandline($script);
-            $process-setTimeout($timeout);
+            $process->setTimeout($timeout);
             $process->run();
             if (! $process->isSuccessful()) {
                 $this->errorBlock($process->getErrorOutput());


### PR DESCRIPTION
Fixes #106. 

I'm not convinced about using `craft\helpers\App::env()` here, it feels a bit wrong in this context (trait), but it also feels gross hardcoding a value, and `App::env()` is the Craft "way". 

I guess the other way to do it is pull from plugin settings / `config/copy.php`, but then we'd be accessing the plugin instance in the trait, which also doesn't feel very clean, but then I also don't use traits so much...

TLDR; Happy for this to be improved!