### PR TITLE
Use the currently checked out branch when pushing code up

### DIFF
--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -117,7 +117,7 @@ class CodeUpAction extends StageAwareBaseAction
         try {
             $this->section("git push ($msg) to $upstream from $branch to master");
             $git->getWorkingCopy()->getWrapper()->streamOutput();
-            $git->push($upstream, "${branch}:master");
+            $git->push($upstream, "$branch:master");
         } catch (GitException $exception) {
             $lines = count(explode(PHP_EOL, $exception->getMessage()));
             $this->output->write(str_repeat("\x1B[1A\x1B[2K", $lines));

--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -115,9 +115,9 @@ class CodeUpAction extends StageAwareBaseAction
         }
 
         try {
-            $this->section("git push ($msg)");
+            $this->section("git push ($msg) to $upstream from $branch to master");
             $git->getWorkingCopy()->getWrapper()->streamOutput();
-            $git->push($upstream, 'master');
+            $git->push($upstream, "${branch}:master");
         } catch (GitException $exception) {
             $lines = count(explode(PHP_EOL, $exception->getMessage()));
             $this->output->write(str_repeat("\x1B[1A\x1B[2K", $lines));


### PR DESCRIPTION
Fixes #105 .

Though we prompt for a branch name in `CodeUpAction::run()` we don't currently actually specify that branch when we call `$git->push()`, meaning we just ignore it and push the `master` branch (as that's the remote branch name we specify in the command.

This fixes that, and extends the console output to make it clear what branch is being pushed to where