### PR TITLE
Feature/dyanmic paths

### DIFF
--- a/bin/craft-copy-import-db.php
+++ b/bin/craft-copy-import-db.php
@@ -31,15 +31,6 @@ if (count($argv) < 2 || stristr($argv[1], '.sql') == false) {
     exit(1);
 }
 
-// Assure the ./storage folder exist
-$storage = $root . '/storage';
-if (!is_dir($storage)) {
-    if (!mkdir($storage)) {
-        echo "Unable to create $storage";
-        exit(1);
-    }
-}
-
 $file = $argv[1];
 
 if (!file_exists($file)) {

--- a/src/Actions/DbDownAction.php
+++ b/src/Actions/DbDownAction.php
@@ -27,9 +27,13 @@ class DbDownAction extends StageAwareBaseAction
     public function run(?string $stage = null)
     {
         $plugin = Plugin::getInstance();
-        $path = './storage/';
-        $transferFile = $path . 'craft-copy-transfer.sql';
-        $backupFile = $path . 'craft-copy-recent.sql';
+
+        $filename = 'craft-copy-transfer.sql';
+
+        $transferFile = $this->getRemoteStoragePath($filename);
+        $transferTarget = $this->getLocalStoragePath($filename);
+        $backupFile = $this->getLocalStoragePath('craft-copy-recent.sql');
+
         $steps = 4;
         $messages = [];
 
@@ -62,7 +66,7 @@ class DbDownAction extends StageAwareBaseAction
 
         // Step 2: Download that dump from remote
         $bar->setMessage($messages[] = "Downloading dump from fortrabbit App {$transferFile}");
-        if ($plugin->ssh->download($transferFile, $transferFile)) {
+        if ($plugin->ssh->download($transferFile, $transferTarget)) {
             $bar->advance();
         }
 
@@ -75,7 +79,7 @@ class DbDownAction extends StageAwareBaseAction
 
         // Step 4: Import
         $bar->setMessage($messages[] = 'Importing dump');
-        if ($plugin->database->import($transferFile)) {
+        if ($plugin->database->import($transferTarget)) {
             $bar->advance();
             $bar->setMessage('Database imported');
         }

--- a/src/Actions/DbUpAction.php
+++ b/src/Actions/DbUpAction.php
@@ -69,6 +69,7 @@ class DbUpAction extends StageAwareBaseAction
 
         // Step 2: Upload that dump to remote
         $bar->setMessage($messages[] = "Uploading local dump to fortrabbit App - {$transferFile}");
+
         if ($plugin->ssh->upload($transferFile, $transferTarget)) {
             $bar->advance();
         }
@@ -116,6 +117,14 @@ class DbUpAction extends StageAwareBaseAction
                         'php craft copy/code/up',
                     ]
                 );
+                return ExitCode::UNSPECIFIED_ERROR;
+            } catch (RemoteException $e) {
+                $this->errorBlock(
+                    [
+                        'An error occurred while creating the backup on the fortrabbit App',
+                    ]
+                );
+                return ExitCode::UNSPECIFIED_ERROR;
             }
 
             // Step 4: Import on remote

--- a/src/Actions/PathAction.php
+++ b/src/Actions/PathAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace fortrabbit\Copy\Actions;
+
+use Craft;
+use ostark\Yii2ArtisanBridge\base\Action;
+use yii\console\ExitCode;
+
+class PathAction extends Action
+{
+
+    public $verbose = false;
+
+    public $interactive = true;
+
+    /**
+     * Return the paths for this environment as JSON
+     *
+     * @param string|null $stage Name of the stage config
+     */
+    public function run(?string $stage = null): int
+    {
+        $paths = [
+            'basePath' => Craft::getAlias('@root'),
+            'storagePath' => Craft::getAlias('@storage'),
+        ];
+
+        $this->output->write(json_encode($paths, JSON_PRETTY_PRINT) . "\r\n");
+        return ExitCode::OK;
+    }
+}

--- a/src/Actions/StageAwareBaseAction.php
+++ b/src/Actions/StageAwareBaseAction.php
@@ -151,6 +151,8 @@ abstract class StageAwareBaseAction extends Action
 
     protected function getRemoteStoragePath(?string $subPath = null): string
     {
-        return $this->stage->storagePath . ($subPath ? "/$subPath" : '');
+        $basePath = $this->stage->storagePath ?? "/srv/app/{$this->stage->app}/htdocs/storage";
+
+        return $basePath . ($subPath ? "/$subPath" : '');
     }
 }

--- a/src/Actions/StageAwareBaseAction.php
+++ b/src/Actions/StageAwareBaseAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace fortrabbit\Copy\Actions;
 
+use Craft;
 use fortrabbit\Copy\Exceptions\StageConfigNotFoundException;
 use fortrabbit\Copy\Helpers\DeployHooksHelper;
 use fortrabbit\Copy\Models\StageConfig;
@@ -141,5 +142,15 @@ abstract class StageAwareBaseAction extends Action
         return Yii::$app->requestedParams[0]
             ?? getenv(Plugin::ENV_DEFAULT_STAGE)
                 ?: 'production';
+    }
+
+    protected function getLocalStoragePath(?string $subPath = null): string
+    {
+        return Craft::getAlias('@storage') . ($subPath ? "/$subPath" : '');
+    }
+
+    protected function getRemoteStoragePath(?string $subPath = null): string
+    {
+        return $this->stage->storagePath . ($subPath ? "/$subPath" : '');
     }
 }

--- a/src/Exceptions/UnreadablePathsException.php
+++ b/src/Exceptions/UnreadablePathsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace fortrabbit\Copy\Exceptions;
+
+use yii\base\Exception;
+
+class UnreadablePathsException extends Exception
+{
+	/**
+     * @var string
+     */
+    public $message = 'Could not read paths from app';
+}

--- a/src/Models/StageConfig.php
+++ b/src/Models/StageConfig.php
@@ -31,6 +31,16 @@ class StageConfig extends Model
     public $gitRemote;
 
     /**
+     * @var string Absolute path to Craft base directory on the remote
+     */
+    public $basePath;
+
+    /**
+     * @var string Absolute path to Craft storage directory on the remote
+     */
+    public $storagePath;
+
+    /**
      * @var array Scripts that run before commands locally
      */
     public $before = [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,6 +18,7 @@ use fortrabbit\Copy\Actions\DbUpAction;
 use fortrabbit\Copy\Actions\FolderDownAction;
 use fortrabbit\Copy\Actions\FolderUpAction;
 use fortrabbit\Copy\Actions\InfoAction;
+use fortrabbit\Copy\Actions\PathAction;
 use fortrabbit\Copy\Actions\SetupAction;
 use fortrabbit\Copy\Actions\VolumesDownAction;
 use fortrabbit\Copy\Actions\VolumesUpAction;
@@ -92,6 +93,7 @@ class Plugin extends BasePlugin
             'db/from-file' => DbImportAction::class,
             'setup' => SetupAction::class,
             'info' => InfoAction::class,
+            'paths' => PathAction::class,
         ];
 
         $options = [


### PR DESCRIPTION
I went down a _little bit_ of a rabbit hole poking around for a fix to #68

TLDR; currently we assume that the Craft `storage` dir is in the project root, and named `storage`. Most of the time that will hold, but not always. We also hard code that all over the place.

This PR refactors the way `copy/db/up` / `copy/db/down` work to read the storage path either direct from Craft (local) or from the stage config (remote stages). 

It also updates `copy/setup` to store the relevant paths in `StageConfig` after reading them from the stage by calling a new action (`PathsAction` / `copy/paths`)  during setup.

I suspect it could use some more work, but I learned a ton about the plugin's internals while I wrote it :)