### PR TITLE
Nitro Craft create ~/.ssh

### DIFF
--- a/src/templates/nitro-craft.sh.twig
+++ b/src/templates/nitro-craft.sh.twig
@@ -66,6 +66,7 @@ preflight() {
     # Create custom ssh config we mount later in the container
     if [ ! -f "$FR_CONTAINER_SSH_CONFIG_FILE" ]; then
         echo "Creating $FR_CONTAINER_SSH_CONFIG_FILE"
+        mkdir -p "$(dirname "$FR_CONTAINER_SSH_CONFIG_FILE")"
         echo "PubkeyAcceptedKeyTypes +ssh-rsa" > $FR_CONTAINER_SSH_CONFIG_FILE
         echo "PreferredAuthentications publickey" >> $FR_CONTAINER_SSH_CONFIG_FILE
         echo "StrictHostKeyChecking no" >> $FR_CONTAINER_SSH_CONFIG_FILE


### PR DESCRIPTION
Fixes

```
$ sudo ./nitro-craft
Creating /root/.ssh/fortrabbit_nitro_config
./nitro-craft: line 69: /root/.ssh/fortrabbit_nitro_config: No such file or directory
./nitro-craft: line 70: /root/.ssh/fortrabbit_nitro_config: No such file or directory
./nitro-craft: line 71: /root/.ssh/fortrabbit_nitro_config: No such file or directory
```

(although running via `sudo` was not a right way here, it just shows the corner case)