### PR TITLE
add /app as git safe directory

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                craft_image_tag: ['7.3', '7.4', '8.0', '8.1']
+                craft_image_tag: ['7.4', '8.0', '8.1']
         steps:
             -   uses: actions/checkout@v1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,8 @@
 name: Docker Build
-on:
-    push:
-        tags:
-            - '[0-9]+.[0-9]+.[0-9]+'
-        branches:
-            - master
-
+on: [push]
 env:
     DOCKER_REGISTRY_IMAGE: ghcr.io/fortrabbit/craft-copy
+    DOCKER_REGISTRY_IMAGE_DEV: ghcr.io/fortrabbit/craft-copy-dev
 
 jobs:
     build:
@@ -39,13 +34,10 @@ jobs:
             -   name: Build docker image
                 working-directory: ./docker
                 run: |
-                    docker build --build-arg CRAFT_IMAGE_TAG="${{ matrix.craft_image_tag }}" \
+                    docker build \
+                        --build-arg CRAFT_IMAGE_TAG="${{ matrix.craft_image_tag }}" \
                         --tag $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }} \
-                        --tag $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }} .
-
-            -   name: Push version image to registry
-                run: |
-                    docker push $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }}
+                        --tag $DOCKER_REGISTRY_IMAGE_DEV:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }} .
 
             # Only publish main image (:8.0) on tag push matching "1.0.5" format
             # https://stackoverflow.com/questions/58862864/github-actions-ci-conditional-regex
@@ -55,6 +47,14 @@ jobs:
                     if [[ ${{ github.event.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                       echo ::set-output name=match::true
                     fi
+
+            # Dev image will contain all builds from branches (ghcr.io/fortrabbit/craft-copy-dev:8.0_feature-branch)
+            -   name: Publish dev image
+                if: steps.check-tag.outputs.match != 'true'
+                run: |
+                    docker push $DOCKER_REGISTRY_IMAGE_DEV:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }}
+
+            # Main image will contain only builds from semantic tags  (ghcr.io/fortrabbit/craft-copy-dev:8.0)
             -   name: Publish main image
                 if: steps.check-tag.outputs.match == 'true'
                 run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #  Changelog
 
+## 1.2.2 - 2022-06-14
+- add /app as git safe directory, [see pull request](https://github.com/fortrabbit/craft-copy/pull/138)
+
 ## 1.2.1 - 2022-03-07
 - Fixed nitro support 
 - Added `copy/nitro/debug commmand` for testing ssh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,13 @@ LABEL org.opencontainers.image.source=https://github.com/fortrabbit/craft-copy
 
 USER root
 
-RUN apk add gzip openssh rsync bash socat su-exec git mysql-client &&\
+RUN apk add --no-cache gzip openssh rsync bash socat su-exec git mysql-client &&\
 mkdir -p /home/www-data/.ssh &&\
 chown www-data:www-data /home/www-data/.ssh/ &&\
 touch /home/www-data/.ssh/config &&\
 echo "Host *.frbit.com" >> /home/www-data/.ssh/config &&\
-echo "    StrictHostKeyChecking no" >> /home/www-data/.ssh/config
+echo "    StrictHostKeyChecking no" >> /home/www-data/.ssh/config  &&\
+git config --global --add safe.directory /app
 
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/src/templates/nitro-craft.sh.twig
+++ b/src/templates/nitro-craft.sh.twig
@@ -6,6 +6,7 @@ DEBUG=false
 # Magic value for docker mac ssh-agent forwarding
 SSH_DOCKER_MAC_SOCK="/run/host-services/ssh-auth.sock"
 
+FR_CONTAINER_DEBUG_BRANCH=""
 FR_CONTAINER_BASE_NAME="ghcr.io/fortrabbit/craft-copy"
 FR_CONTAINER_SSH_CONFIG_FILE="$HOME/.ssh/fortrabbit_nitro_config"
 
@@ -33,7 +34,11 @@ get_php_version() {
 }
 
 get_container_name() {
-    echo "$FR_CONTAINER_BASE_NAME:$(get_php_version)"
+    if [[ -n "$FR_CONTAINER_DEBUG_BRANCH" ]]; then
+        echo "$FR_CONTAINER_BASE_NAME-dev:$(get_php_version)_$FR_CONTAINER_DEBUG_BRANCH"
+    else
+        echo "$FR_CONTAINER_BASE_NAME:$(get_php_version)"
+    fi
 }
 
 get_ssh_socket_name() {


### PR DESCRIPTION
Recent versions of git added extra security protections when directories are not owned by the current user, which causes issues with craft copy running in nitro. This pull request solves it by adding the /app dir to the "safe directories" list in git.

Here is a screenshot of the error when trying to run `./nitro-craft copy/code/up`
<img width="898" alt="Screenshot 2022-06-13 at 19 29 49" src="https://user-images.githubusercontent.com/54077578/173410889-c651073e-a360-4ad5-831e-8c474aa52905.png">

This are the security changes made to git that caused the error message:
https://github.blog/2022-04-12-git-security-vulnerability-announced/

This pull request also makes it easier to debug container issues in the future, allowing people to easily run an alternative dev version of the image by setting the `FR_CONTAINER_DEBUG_BRANCH` variable in the local nitro-craft script :)