### PR TITLE
use git system config and build docker image locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #  Changelog
 
+## 1.2.4 - 2022-06-15
+- build docker image locally, [see pull request](https://github.com/fortrabbit/craft-copy/pull/139)
+
 ## 1.2.3 - 2022-06-14
 - correct Github docker image builds
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,16 +4,16 @@ LABEL org.opencontainers.image.source=https://github.com/fortrabbit/craft-copy
 
 USER root
 
-RUN apk add --no-cache gzip openssh rsync bash socat su-exec git mysql-client &&\
-mkdir -p /home/www-data/.ssh &&\
-chown www-data:www-data /home/www-data/.ssh/ &&\
-touch /home/www-data/.ssh/config &&\
-echo "Host *.frbit.com" >> /home/www-data/.ssh/config &&\
-echo "    StrictHostKeyChecking no" >> /home/www-data/.ssh/config  &&\
-git config --global --add safe.directory /app
-
 COPY ./entrypoint.sh /
-RUN chmod +x /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh", "./craft"]
-CMD ["help"]
+RUN apk add --no-cache gzip openssh rsync bash socat su-exec git mysql-client &&\
+    mkdir -p /home/www-data/.ssh &&\
+    chown www-data:www-data /home/www-data/.ssh/ &&\
+    touch /home/www-data/.ssh/config &&\
+    echo "Host *.frbit.com" >> /home/www-data/.ssh/config &&\
+    echo "    StrictHostKeyChecking no" >> /home/www-data/.ssh/config  &&\
+    chmod +x /entrypoint.sh &&\
+    git config --system --add safe.directory /app
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["./craft", "help"]

--- a/src/Actions/NitroSetupAction.php
+++ b/src/Actions/NitroSetupAction.php
@@ -24,7 +24,7 @@ class NitroSetupAction extends Action
     private const SUCCESS_MESSAGE = 'This script should be run from your host machine (not inside of Nitro) 
                                      and should be used instead of `nitro craft` when running Craft Copy console commands 
                                      (all other Craft console commands should work too)
-                                     e.g. `./nitro-craft copy/info`
+                                     e.g. `./nitro-craft copy/db/up`
 
                                      For full documentation see the Craft Copy README
                                      https://github.com/fortrabbit/craft-copy/#craft-nitro-support';

--- a/src/templates/nitro-craft.sh.twig
+++ b/src/templates/nitro-craft.sh.twig
@@ -3,10 +3,10 @@
 PHP_VERSION="{{ phpVersion }}"
 COMMAND=${1:-"help"}
 DEBUG=false
+
 # Magic value for docker mac ssh-agent forwarding
 SSH_DOCKER_MAC_SOCK="/run/host-services/ssh-auth.sock"
 
-FR_CONTAINER_DEBUG_BRANCH=""
 FR_CONTAINER_BASE_NAME="ghcr.io/fortrabbit/craft-copy"
 FR_CONTAINER_SSH_CONFIG_FILE="$HOME/.ssh/fortrabbit_nitro_config"
 
@@ -34,11 +34,7 @@ get_php_version() {
 }
 
 get_container_name() {
-    if [[ -n "$FR_CONTAINER_DEBUG_BRANCH" ]]; then
-        echo "$FR_CONTAINER_BASE_NAME-dev:$(get_php_version)_$FR_CONTAINER_DEBUG_BRANCH"
-    else
-        echo "$FR_CONTAINER_BASE_NAME:$(get_php_version)"
-    fi
+    echo "$FR_CONTAINER_BASE_NAME:$(get_php_version)"
 }
 
 get_ssh_socket_name() {
@@ -85,11 +81,14 @@ preflight() {
         ssh-add -l
     fi
 
+    docker build \
+        --build-arg CRAFT_IMAGE_TAG=$PHP_VERSION \
+        --tag "$(get_container_name)" \
+        vendor/fortrabbit/craft-copy/docker
 }
 
 run() {
-    docker run -it \
-        --rm \
+    docker run -it --rm \
         -v "$PWD":/app \
         -v "$HOME"/.gitconfig:/home/www-data/.gitconfig \
         -v "$FR_CONTAINER_SSH_CONFIG_FILE":/home/www-data/.ssh/config:ro \

--- a/src/templates/nitro-craft.sh.twig
+++ b/src/templates/nitro-craft.sh.twig
@@ -96,7 +96,8 @@ run() {
         -v "$(get_ssh_socket_name)":"$(get_ssh_socket_name)" \
         -e SSH_AUTH_SOCK="$(get_ssh_socket_name)" \
         --network=nitro-network \
-        "$(get_container_name)" "$@"
+        "$(get_container_name)" \
+        ./craft $@
 }
 
 init() {

--- a/src/templates/nitro-craft.sh.twig
+++ b/src/templates/nitro-craft.sh.twig
@@ -81,7 +81,13 @@ preflight() {
         ssh-add -l
     fi
 
-    docker build \
+    docker_extra="--quiet"
+    if [ $DEBUG == true ]; then
+      docker_extra=""
+    fi
+
+    echo "Building docker container image, please be patient..."
+    docker build $docker_extra \
         --build-arg CRAFT_IMAGE_TAG=$PHP_VERSION \
         --tag "$(get_container_name)" \
         vendor/fortrabbit/craft-copy/docker


### PR DESCRIPTION
## Git system config
The previous bugfix (https://github.com/fortrabbit/craft-copy/pull/138) did not work because after adding the setting we override the global git config with the users git config. So here I set it in the system config instead, to avoid that conflict.


## Local docker build
Repeatedly testing this by rebuilding container images and trying to keep the version of the craft-copy extension and the craft-copy docker image in sync I realised: why make it so difficult? Why try to sync two sources of truth? So in this pull request I added a simple local build of the docker image, no need to rely on the Github actions to build images anymore.

For example, this makes it possible to test this feature branch easily, by only running these commands:
```
composer require fortrabbit/craft-copy:dev-feature/git-system-config
nitro craft copy/nitro/setup
./nitro-craft copy/code/up
```

No need to wait for github actions to finish. No need to set a custom image tag to use for debugging. This will automatically build the correct image version locally.


## Entrypoint vs command
I've also moved the `"./craft"` part from the `ENTRYPOINT` to the `nitro-craft` wrapper script. This is to make it easier to start the image with a shell for debugging, while still letting the entrypoint script fix file ownerships.

Before I had to specify to run entrypoint script to open a shell, took me a long time to figure out:
`docker run -it --rm  -v "$PWD":/app --entrypoint=/entrypoint.sh ghcr.io/fortrabbit/craft-copy:8.0 sh`

Now this happens automatically:
`docker run -it --rm  -v "$PWD":/app ghcr.io/fortrabbit/craft-copy:8.0 sh`

And still the wrapper script works as before:
`./nitro-craft`

What changed is that you used to be able to do this:
`docker run -it --rm  -v "$PWD":/app ghcr.io/fortrabbit/craft-copy:8.0 copy/code/up`
Now you have to do this:
`docker run -it --rm  -v "$PWD":/app ghcr.io/fortrabbit/craft-copy:8.0 ./craft copy/code/up`
But no one uses it like that I think :)