### PR TITLE
Prevent Project Config (warnings) in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #  Changelog
 
+## 2.2.0 - 2022-11-08
+- show warning if composer plugins are not allowed
+- remove project config after applying (via `fortrabbit/craft-auto-migrate`)
+
 ## 2.1.1 - 2022-06-16
 - add /app as git safe directory, [see pull request](https://github.com/fortrabbit/craft-copy/pull/138)
 - build docker image locally, [see pull request](https://github.com/fortrabbit/craft-copy/pull/139)

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/process": "^5.0 | ^6.0",
         "vlucas/phpdotenv": "^3.4.0 | ^5.4",
         "symfony/yaml": "^4.2 | ^5.0",
-        "fortrabbit/craft-auto-migrate":"^2.4.0"
+        "fortrabbit/craft-auto-migrate":"^2.5.0"
     },
     "require-dev": {
         "craftcms/phpstan": "dev-main",


### PR DESCRIPTION
The actual changes happen in `fortrabbit/craft-auto-migrate`.
This additional check assures that the composer plugin is not blocked.

Context: https://getcomposer.org/doc/06-config.md#allow-plugins

Sister tickets

* PR https://github.com/fortrabbit/craft-auto-migrate/pull/10
* Issue https://github.com/craftcms/cms/issues/11971