### PR TITLE
Prevent regeneration of project.yaml files in production

### DIFF
--- a/src/Actions/StageAwareBaseAction.php
+++ b/src/Actions/StageAwareBaseAction.php
@@ -50,7 +50,7 @@ abstract class StageAwareBaseAction extends Action
      */
     protected function beforeRun()
     {
-        if ($this->isFortrabbitEnv()) {
+        if (Plugin::isFortrabbitEnv()) {
             $this->errorBlock("
                 It looks like you are running this command in a fortrabbit app container. 
                 That won't work. Instead, you need to run Craft Copy commands from your local development environment.
@@ -146,8 +146,4 @@ abstract class StageAwareBaseAction extends Action
                 ?: 'production';
     }
 
-    protected function isFortrabbitEnv(): bool
-    {
-        return getenv('APP_SECRETS') === '/etc/secrets.json';
-    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,6 +82,8 @@ class Plugin extends BasePlugin
     {
         parent::init();
 
+        $this->dontWriteYamlAutomatically();
+
         // Only console matters
         if ( ! (Craft::$app instanceof ConsoleApplication)) {
             return;
@@ -92,8 +94,6 @@ class Plugin extends BasePlugin
         $this->registerComponents();
 
         $this->registerEventHandlers();
-
-        $this->dontWriteYamlAutomatically();
 
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -83,7 +83,7 @@ class Plugin extends BasePlugin
         parent::init();
 
         // Only console matters
-        if (! (Craft::$app instanceof ConsoleApplication)) {
+        if ( ! (Craft::$app instanceof ConsoleApplication)) {
             return;
         }
 
@@ -92,6 +92,9 @@ class Plugin extends BasePlugin
         $this->registerComponents();
 
         $this->registerEventHandlers();
+
+        $this->dontWriteYamlAutomatically();
+
     }
 
     private function registerConsoleCommands(): void
@@ -139,13 +142,13 @@ class Plugin extends BasePlugin
             [
                 'stage' => StageConfigAccess::class,
                 'database' => fn() => new DatabaseService([
-                    'db' => Craft::$app->getDb(),
-                ]),
+                                                              'db' => Craft::$app->getDb(),
+                                                          ]),
                 'git' => fn() => GitService::fromDirectory(Craft::getAlias('@root') ?: CRAFT_BASE_PATH),
                 'rsync' => fn() => RsyncService::remoteFactory($this->stage->get()->sshUrl),
                 'ssh' => fn() => new SshService([
-                    'remote' => $this->stage->get()->sshUrl,
-                ]),
+                                                    'remote' => $this->stage->get()->sshUrl,
+                                                ]),
             ]
         );
     }
@@ -162,5 +165,17 @@ class Plugin extends BasePlugin
             Connection::EVENT_BEFORE_CREATE_BACKUP,
             new IgnoredBackupTablesHandler()
         );
+    }
+
+    private function dontWriteYamlAutomatically(): void
+    {
+        if (Plugin::isFortrabbitEnv()) {
+            Craft::$app->getProjectConfig()->writeYamlAutomatically = false;
+        }
+    }
+
+    public static function isFortrabbitEnv(): bool
+    {
+        return getenv('APP_SECRETS') === '/etc/secrets.json';
     }
 }


### PR DESCRIPTION
This should avoid conflicts with Project Config.
Working theory: If there is no "external project config" Craft can not detect (and warn about) any changes.