### PR TITLE
Allow customising commit message made in code/up command

### DIFF
--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -94,7 +94,13 @@ class CodeUpAction extends StageAwareBaseAction
         if ($status = $git->getWorkingCopy()->getStatus()) {
             // Changed files
             $this->noteBlock('Uncommitted changes:' . PHP_EOL . $status);
-            $defaultMessage = $this->interactive ? null : $this->commitMessage;
+
+            $commitMessage = $this->commitMessage;
+            if ($this->commitMessage == "1") {
+                $commitMessage = "init Craft";
+            }
+
+            $defaultMessage = $this->interactive ? null : $commitMessage;
 
             if (! $msg = $this->ask(
                 'Enter a commit message, or leave it empty to abort the commit',

--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -18,6 +18,8 @@ use yii\console\ExitCode;
 
 class CodeUpAction extends StageAwareBaseAction
 {
+    public string $commitMessage = "init Craft";
+
     public function __construct(
         string $id,
         Commands $controller,
@@ -92,7 +94,7 @@ class CodeUpAction extends StageAwareBaseAction
         if ($status = $git->getWorkingCopy()->getStatus()) {
             // Changed files
             $this->noteBlock('Uncommitted changes:' . PHP_EOL . $status);
-            $defaultMessage = $this->interactive ? null : 'init Craft';
+            $defaultMessage = $this->interactive ? null : $this->commitMessage;
 
             if (! $msg = $this->ask(
                 'Enter a commit message, or leave it empty to abort the commit',

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -125,6 +125,7 @@ class Plugin extends BasePlugin
             'a' => 'app',
             'e' => 'env',
             'f' => 'force',
+            'm' => 'commitMessage',
         ];
 
         $group = (new ActionGroup('copy', 'Copy Craft between environments.'))


### PR DESCRIPTION
As reported in https://github.com/fortrabbit/craft-copy/issues/158, this PR aims to allow customising the commit message used in interactive mode.