### PR TITLE
Revert mysql client issues workaround

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,20 +16,19 @@ jobs:
             matrix:
                 craft_image_tag: ['7.4', '8.0', '8.1']
         steps:
-            -   uses: actions/checkout@v1
+            -   uses: actions/checkout@v3
 
             -   name: Login to GitHub Container Registry
-                uses: docker/login-action@v1
+                uses: docker/login-action@v2
                 with:
                     registry: ghcr.io
                     username: ${{ github.repository_owner }}
                     password: ${{ secrets.GITHUB_TOKEN }}
 
-            -   name: Slugify branch/tag name
+            -   name: Slugify branch name
                 shell: bash
-                run: echo "##[set-output name=slug;]$(echo $GITHUB_REF | sed -E 's/refs\/(heads|tags)\///g' | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)"
-                id: branch_slug
-                # Usage: ${{ steps.branch_slug.outputs.slug }}
+                run: echo "branch_slug=$(echo $GITHUB_REF | sed -E 's/refs\/(heads|tags)\///g' | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)" >> $GITHUB_ENV
+                # Usage: ${{ env.branch_slug }}
 
             -   name: Build docker image
                 working-directory: ./docker
@@ -37,8 +36,8 @@ jobs:
                     docker build \
                         --build-arg CRAFT_IMAGE_TAG="${{ matrix.craft_image_tag }}" \
                         --tag $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }} \
-                        --tag $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }} \
-                        --tag $DOCKER_REGISTRY_IMAGE_DEV:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }} \
+                        --tag $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }}_${{ env.branch_slug }} \
+                        --tag $DOCKER_REGISTRY_IMAGE_DEV:${{ matrix.craft_image_tag }}_${{ env.branch_slug }} \
                         .
 
             # Only publish main image (:8.0) on tag push matching "1.0.5" format
@@ -56,7 +55,7 @@ jobs:
             -   name: Publish dev image
                 if: steps.check-tag.outputs.match != 'true'
                 run: |
-                    docker push $DOCKER_REGISTRY_IMAGE_DEV:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }}
+                    docker push $DOCKER_REGISTRY_IMAGE_DEV:${{ matrix.craft_image_tag }}_${{ env.branch_slug }}
 
             # Main image will contain only builds from semantic tags
             # ghcr.io/fortrabbit/craft-copy:8.0 - removed push to not break old installs of craft-copy that depend on old version of the image
@@ -64,4 +63,4 @@ jobs:
             -   name: Publish main image
                 if: steps.check-tag.outputs.match == 'true'
                 run: |
-                    docker push $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }}_${{ steps.branch_slug.outputs.slug }}
+                    docker push $DOCKER_REGISTRY_IMAGE:${{ matrix.craft_image_tag }}_${{ env.branch_slug }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #  Changelog
 
+## 2.3.2 - 2023-04-05
+- Revert mysql command line tweaks
+
 ## 2.3.1 - 2023-04-03
 - More tweaks on the mysql command line options
 

--- a/bin/craft-copy-import-db.php
+++ b/bin/craft-copy-import-db.php
@@ -69,7 +69,7 @@ $tokens = [
     '{MYSQL_DATABASE}' => getenv('MYSQL_DATABASE'),
 ];
 
-$cmd = 'mysql --defaults-extra-file={EXTRA_FILE} --ssl-mode=DISABLED --force {MYSQL_DATABASE} < {FILE} && echo 1';
+$cmd = 'mysql --defaults-extra-file={EXTRA_FILE} --force {MYSQL_DATABASE} < {FILE} && echo 1';
 $cmd = str_replace(array_keys($tokens), array_values($tokens), $cmd);
 
 $process = \Symfony\Component\Process\Process::fromShellCommandline($cmd);

--- a/src/Services/Database.php
+++ b/src/Services/Database.php
@@ -44,8 +44,6 @@ class Database extends Component
     {
         $file = $this->prepareFile($file);
 
-        $this->alterCraftDefaultRestoreCommand($file);
-
         $this->db->restore($file);
 
         return $file;
@@ -89,33 +87,7 @@ class Database extends Component
             $backupCommand
         );
 
-        // Disable single-transaction for now
-        $backupCommand = str_replace(
-            ' --single-transaction',
-            '',
-            $backupCommand
-        );
-
-        // Disable ssl-mode for now
-        $backupCommand = str_replace(
-            '--no-tablespaces',
-            '--no-tablespaces --ssl-mode=DISABLED',
-            $backupCommand
-        );
-
         Craft::$app->getConfig()->getGeneral()->backupCommand = $backupCommand;
     }
 
-    protected function alterCraftDefaultRestoreCommand(): void
-    {
-        // Determine the command that should be executed
-        $restoreCommand = $this->db->getSchema()->getDefaultRestoreCommand();
-
-        Craft::$app->getConfig()->getGeneral()->restoreCommand = str_replace(
-            '.cnf"',
-            '.cnf" --ssl-mode=DISABLED',
-            $restoreCommand
-        );
-
-    }
 }


### PR DESCRIPTION
We had an ongoing issue on our platform with mysql-client and mysqldump version 5.7.41. We have now reverted to 5.7.40 and this workaround is no longer needed.

The workaround itself was also causing issues for some clients with mysqldump saying option `--ssl-mode` does not exist. This resolves those issues as well.