### PR TITLE
Add support for no existing repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #  Changelog
 
+## 2.4.1 - 2023-04-19
+- Add support for no existing repo with new git client
+
 ## 2.4.0 - 2023-04-17
 - Replace `cpliakas/git-wrapper` with `gitonomy/gitlib`
 - Allow customising commit message made in `code/up` command


### PR DESCRIPTION
As reported in https://github.com/fortrabbit/craft-copy/issues/167, the new Gitonomy client breaks existing functionality. This PR enables support for projects with no existing repos, creating one instead of failing in unexpected ways.