### PR TITLE
SSH check with password disabled

### DIFF
--- a/src/Actions/SetupAction.php
+++ b/src/Actions/SetupAction.php
@@ -79,7 +79,7 @@ class SetupAction extends Action
         );
         $ssh = $this->checkAndWrite(
             'Testing SSH access',
-            $this->canExecBinary("ssh {$config->sshUrl} secrets")
+            $this->canExecBinary("ssh {$config->sshUrl} -o PasswordAuthentication=no secrets")
         );
 
         if (! $mysql) {


### PR DESCRIPTION
By disabling password auth we avoid a prompt and the user gets a better error message.

Related issue: https://github.com/fortrabbit/craft-copy/issues/164