### PR TITLE
V1 updates

### DIFF
--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -94,9 +94,9 @@ class CodeUpAction extends StageAwareBaseAction
             // Changed files
             $this->noteBlock('Uncommitted changes:' . PHP_EOL . $status);
 
-			$defaultMessage = $this->commitMessage ? $this->commitMessage : $defaultMessage;
+			$defaultMessage = $this->commitMessage ? $this->commitMessage : "Push latest to $upstream";
 			//interactive must be false for custom commit message
-            $defaultMessage = $this->interactive ? null :  "Push latest to $upstream";
+            $defaultMessage = $this->interactive ? null :  $defaultMessage;
 
             if (! $msg = $this->ask(
                 'Enter a commit message, or leave it empty to abort the commit',

--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -93,6 +93,7 @@ class CodeUpAction extends StageAwareBaseAction
             $this->noteBlock('Uncommitted changes:' . PHP_EOL . $status);
 
             $defaultMessage = $this->interactive ? null :  "Auto push latest to $upstream";
+            $defaultMessage = $this->commitMessage ? $this->commitMessage : $defaultMessage;
 
             if (! $msg = $this->ask(
                 'Enter a commit message, or leave it empty to abort the commit',

--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -92,8 +92,9 @@ class CodeUpAction extends StageAwareBaseAction
             // Changed files
             $this->noteBlock('Uncommitted changes:' . PHP_EOL . $status);
 
-            $defaultMessage = $this->interactive ? null :  "Auto push latest to $upstream";
-            $defaultMessage = $this->commitMessage ? $this->commitMessage : $defaultMessage;
+			$defaultMessage = $this->commitMessage ? $this->commitMessage : $defaultMessage;
+			//interactive must be false for custom commit message
+            $defaultMessage = $this->interactive ? null :  "Push latest to $upstream";
 
             if (! $msg = $this->ask(
                 'Enter a commit message, or leave it empty to abort the commit',

--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -91,7 +91,8 @@ class CodeUpAction extends StageAwareBaseAction
         if ($status = $git->getWorkingCopy()->getStatus()) {
             // Changed files
             $this->noteBlock('Uncommitted changes:' . PHP_EOL . $status);
-            $defaultMessage = $this->interactive ? null : 'init Craft';
+
+            $defaultMessage = $this->interactive ? null :  "Auto push latest to $upstream";
 
             if (! $msg = $this->ask(
                 'Enter a commit message, or leave it empty to abort the commit',
@@ -115,9 +116,9 @@ class CodeUpAction extends StageAwareBaseAction
         }
 
         try {
-            $this->section("git push ($msg)");
+            $this->section("git push ($msg) to $upstream from $branch to master");
             $git->getWorkingCopy()->getWrapper()->streamOutput();
-            $git->push($upstream, 'master');
+            $git->push($upstream, "$branch:master");
         } catch (GitException $exception) {
             $lines = count(explode(PHP_EOL, $exception->getMessage()));
             $this->output->write(str_repeat("\x1B[1A\x1B[2K", $lines));

--- a/src/Actions/CodeUpAction.php
+++ b/src/Actions/CodeUpAction.php
@@ -21,6 +21,8 @@ class CodeUpAction extends StageAwareBaseAction
      */
     protected $localVolume;
 
+    public $commitMessage = '';
+
     public function __construct(
         string $id,
         Commands $controller,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -108,6 +108,7 @@ class Plugin extends BasePlugin
             'a' => 'app',
             'e' => 'env',
             'f' => 'force',
+            'm' => 'commitMessage',
         ];
 
         $group = (new ActionGroup('copy', 'Copy Craft between environments.'))


### PR DESCRIPTION
This adds pushing from currently selected branch and adding custom commit messages for non-interactive mode. 

It also adds the name of the name of the app being pushed to in the default msg.

I have several Craft v3 sites that need to stay v3 for various reasons and this effectively back-ports these two important features.